### PR TITLE
Use correct URDFs for head_v1 and torso_v0

### DIFF
--- a/cob_description/urdf/head_v1/head.urdf.xacro
+++ b/cob_description/urdf/head_v1/head.urdf.xacro
@@ -4,11 +4,11 @@
        xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
-	<include filename="$(find cob_description)/ros/urdf/head_v1/head.gazebo.xacro" />
-	<include filename="$(find cob_description)/ros/urdf/head_v1/head.transmission.xacro" />
-	<include filename="$(find cob_description)/ros/urdf/sensors/prosilica.urdf.xacro" />
-	<include filename="$(find cob_description)/ros/urdf/sensors/kinect.urdf.xacro" />
-	<!--include filename="$(find cob_description)/ros/urdf/sensors/hokuyo_SR400_laser.urdf.xacro" /-->
+	<include filename="$(find cob_description)/urdf/head_v1/head.gazebo.xacro" />
+	<include filename="$(find cob_description)/urdf/head_v1/head.transmission.xacro" />
+	<include filename="$(find cob_description)/urdf/sensors/prosilica.urdf.xacro" />
+	<include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
+	<!--include filename="$(find cob_description)/urdf/sensors/hokuyo_SR400_laser.urdf.xacro" /-->
 
 	<xacro:macro name="cob_head_v1" params="name parent *origin">
 

--- a/cob_description/urdf/torso_v0/torso.urdf.xacro
+++ b/cob_description/urdf/torso_v0/torso.urdf.xacro
@@ -4,8 +4,8 @@
        xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface"
        xmlns:xacro="http://ros.org/wiki/xacro">
 
-	<include filename="$(find cob_description)/ros/urdf/torso_v0/torso.gazebo.xacro" />
-	<include filename="$(find cob_description)/ros/urdf/torso_v0/torso.transmission.xacro" />
+	<include filename="$(find cob_description)/urdf/torso_v0/torso.gazebo.xacro" />
+	<include filename="$(find cob_description)/urdf/torso_v0/torso.transmission.xacro" />
 
 	<xacro:macro name="cob_torso_v0" params="name parent *origin">
 


### PR DESCRIPTION
The gazebo URDF files of head_v1 and torso_v0 have been included from the cob_description/ros directory. In the new repository layout the URDFs have been moved to cob_description/urdf.

This commit uses the correct include directory for head_v1 and torso_v0.
